### PR TITLE
Add .travis.yaml config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: c
+compiler:
+  - gcc
+  - clang
+env:
+  # Default build. Release.
+  - BUILD_ARGS=""
+  # Build using OpenSSL Libary for MD5/SHA1 hash functions
+  - BUILD_ARGS="--with-openssl"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install automake1.9
+script: 
+  - autoreconf --force --install && ./configure $BUILD_ARGS .. && make


### PR DESCRIPTION
This change is a two step process:

1.) This travis.yaml file tells travis that we want to build ike-scan using both gcc and clang as well as with different build options defined below.  It setups the target build servers environment and builds the necessary derived files we need to offer up a build of ike-scan.  If a build were to fail in any branch of this project (including pull requests) it will show in the pull request whether the change will cause the build to fail and report back.

2.) You would need to use the github SSO to login to Travis here (https://travis-ci.org/) and enable travis for your ike-scan repo.  You would then need to open the setting on the GitHub project and enable the travis service hook.  Once this is done, all the features mentioned above will be live.

I realize this is a big change, so feel free to let me know if more discussion is required before this goes in.
