### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: c
 compiler:
   - gcc
   - clang
+arch:
+  - amd64
+  - ppc64le
 env:
   # Default build. Release.
   - BUILD_ARGS=""
@@ -14,6 +17,8 @@ matrix:
   exclude:
     - compiler: clang
       env: BUILD_ARGS="--enable-gcov"
+    - compiler: clang
+      arch: ppc64le
 before_install:
   - sudo apt-get update -qq
   - sudo pip install cpp-coveralls


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/ike-scan/builds/191746155 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!