### PR TITLE
Fix a couple autoconf tests on Xcode 12

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -145,7 +145,7 @@ int does_int64_work()
   return 1;
 }
 main() {
-  exit(! does_int64_work());
+  return ! does_int64_work();
 }],
 [Ac_cachevar=yes],
 [Ac_cachevar=no],
@@ -201,7 +201,7 @@ int does_int64_snprintf_work()
   return 1;
 }
 main() {
-  exit(! does_int64_snprintf_work());
+  return ! does_int64_snprintf_work();
 }],
 [pgac_cv_snprintf_long_long_int_format=$pgac_format; break],
 [],


### PR DESCRIPTION
Xcode 12 changed its default compile flags to include `-Werror,-Wimplicit-function-declaration`  One place this tends to cause problems is in configure scripts where that warning may have existed for a long time without anyone noticing.  Now suddenly those compile tests will fail, causing other compile problems.

In the case of ike-scan, these two tests call `exit()` without `#include <stdlib.h>`.  The easiest fix, though, is to just return directly from `main()` so that we don't have to use `exit()` at all.