### PR TITLE
Remove test string dependence on C library

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2024-09-15 Roy Hills <Roy.Hills@hotmail.com>
+
+	* check-error: Change invalid option test string from
+	  "ike-scan: unrecognized option", to "^Usage: ike-scan".
+	  This fixes a test failure on cygwin because it's newlib based C
+	  library outputs "ike-scan: unknown option" instead of
+	  "ike-scan: unrecognized option" that is used by glibc and BSD libc.
+
 2022-10-02 Roy Hills <Roy.Hills@hotmail.com>
 
 	* acinclude.m4: Replaced obsolete autoconf macros AC_TRY_COMPILE with

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 	  This fixes a test failure on cygwin because it's newlib based C
 	  library outputs "ike-scan: unknown option" instead of
 	  "ike-scan: unrecognized option" that is used by glibc and BSD libc.
+	  https://github.com/royhills/ike-scan/pull/45
 
 2022-10-02 Roy Hills <Roy.Hills@hotmail.com>
 

--- a/check-error
+++ b/check-error
@@ -119,7 +119,7 @@ if test $? -eq 0; then
    echo "FAILED"
    exit 1
 fi
-grep 'ike-scan: unrecognized option ' $TMPFILE >/dev/null
+grep '^Usage: ike-scan ' $TMPFILE >/dev/null
 if test $? -ne 0; then
    rm -f $TMPFILE
    echo "FAILED"


### PR DESCRIPTION
Change test string for the invalid option test in `check-error` so it doesn't depend on the output from `getopt_long_only()` in the C library.

The Newlib based C library on cygwin gives a different output (`ike-scan: unknown option`) compared with glibc and BSD libc (`ike-scan: unrecognized option`). This was causing the `check-error` test to fail on Windows.